### PR TITLE
Use root-relative image paths and share worker frame constants

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -44,11 +44,11 @@ button:hover {background:#666;}
 #shopPanel{position:fixed; top:88px; left:0; bottom:0; width:330px; background:#222; border-right:1px solid #3a3a3a; z-index:2150; display:none; overflow-y:auto; padding:12px; box-shadow:8px 0 20px rgba(0,0,0,.35);}
 #shopHeader{display:flex; align-items:center; justify-content:space-between; margin-bottom:10px;}
 .card{position:relative; width:300px; height:438px; margin:10px auto; image-rendering:pixelated; border-radius:12px; box-shadow:0 10px 18px rgba(0,0,0,.35); cursor:pointer; overflow:hidden;}
-.card.drov {background:url('../images/CardDrovosek.png') center/cover no-repeat;}
-.card.miner {background:url('../images/CardMiner.png') center/cover no-repeat;}
-.card.base {background:url('../images/CardBase.png') center/cover no-repeat;}
-.card.fermer {background:url('../images/Cardeda.png') center/cover no-repeat;}
-.card.houseeat {background:url('../images/CardHouseEat.png') center/cover no-repeat;}
+.card.drov {background:url('./images/CardDrovosek.png') center/cover no-repeat;}
+.card.miner {background:url('./images/CardMiner.png') center/cover no-repeat;}
+.card.base {background:url('./images/CardBase.png') center/cover no-repeat;}
+.card.fermer {background:url('./images/Cardeda.png') center/cover no-repeat;}
+.card.houseeat {background:url('./images/CardHouseEat.png') center/cover no-repeat;}
 .card .title{position:absolute; top:18px; left:84px; right:16px; font-size:13px; color:var(--cream); text-shadow:0 1px 0 #000;}
 .card .cost {position:absolute; top:46px; left:84px; right:16px; font-size:12px; color:var(--cream); text-shadow:0 1px 0 #000;}
 .card .desc {position:absolute; left:30px; right:30px; bottom:22px; font-size:12px; line-height:1.25; color:var(--cream); text-shadow:0 1px 0 #000;}

--- a/js/constants.js
+++ b/js/constants.js
@@ -11,20 +11,20 @@ export const WORKER_COST_FOOD = 10;
 
 // Спрайты
 export const WC_FRAMES = [
-  '../images/Drovosek1.png',
-  '../images/Drovosek2.png',
-  '../images/Drovosek3.png',
-  '../images/Drovosek4.png'
+  './images/Drovosek1.png',
+  './images/Drovosek2.png',
+  './images/Drovosek3.png',
+  './images/Drovosek4.png'
 ];
 export const MINER_FRAMES = [
-  '../images/Miner1.png',
-  '../images/Miner2.png',
-  '../images/Miner3.png',
-  '../images/Miner4.png'
+  './images/Miner1.png',
+  './images/Miner2.png',
+  './images/Miner3.png',
+  './images/Miner4.png'
 ];
 export const FERM_FRAMES = [
-  '../images/ferma1.png',
-  '../images/ferma2.png',
-  '../images/ferma3.png',
-  '../images/ferma4.png'
+  './images/ferma1.png',
+  './images/ferma2.png',
+  './images/ferma3.png',
+  './images/ferma4.png'
 ];

--- a/js/worker.js
+++ b/js/worker.js
@@ -1,13 +1,11 @@
 import { resources, schedulePlayerSave, addXP } from './resources.js';
 import { showToast } from './ui.js';
-import { WORKER_COST_FOOD, WORKER_DURATION_MS } from './constants.js';  // Если добавишь constants.js, иначе hardcode
+import { WORKER_COST_FOOD, WORKER_DURATION_MS, WC_FRAMES, MINER_FRAMES, FERM_FRAMES } from './constants.js';  // Если добавишь constants.js, иначе hardcode
 
 // ===== Константы рабочих =====
-const WC_FRAMES = ['./images/Drovosek1.png','./images/Drovosek2.png','./images/Drovosek3.png','./images/Drovosek4.png'];
-const MINER_FRAMES= ['./images/Miner1.png','./images/Miner2.png','./images/Miner3.png','./images/Miner4.png'];
-const FERM_FRAMES = ['./images/ferma1.png','./images/ferma2.png','./images/ferma3.png','./images/ferma4.png'];
 const IDLE_INDEX = 1, FRAME_INTERVAL_MS = 160;
 const STEP_SPEED = 0.0009, ARRIVE_EPS = 0.00008;
+export const FRAME_SETS = { woodcutter: WC_FRAMES, miner: MINER_FRAMES, farmer: FERM_FRAMES };
 
 // ===== Сеты рабочих =====
 export const woodcuttersByHome = new Map();


### PR DESCRIPTION
## Summary
- reference images from index.html using `./images` paths
- export worker frame sets and consume them in worker module

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fe8002cc8331a5facd8a9702a1e0