### PR TITLE
feat: sync workers with Firestore

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -91,7 +91,7 @@ function startRealtime(){
   });
 
   // Подписка на рабочих (если реализовано в worker.js)
-  startWorkersRealtime(db, uid);
+  startWorkersRealtime(uid);
 }
 
 // ===== Инит игры =====


### PR DESCRIPTION
## Summary
- store workers in Firestore with local fallback when hiring
- subscribe to player workers in realtime and clean up on expiration
- remove expired workers from Firestore or cache

## Testing
- `node --check js/worker.js`
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a60608a250833192a358dbf0260371