### PR TITLE
Replenish resources around houses over time

### DIFF
--- a/js/buildings.js
+++ b/js/buildings.js
@@ -16,6 +16,17 @@ const BUILDING_ICONS = {
 export const markers = new Map();       // id -> Leaflet marker
 export const buildingData = new Map();  // id -> {type, lat, lng, level, iconUrl?, ...}
 
+// ===== Хелпер для получения координат домов заданного типа =====
+export function getDomAnchors(type) {
+  const arr = [];
+  buildingData.forEach(b => {
+    if (b.type === type) {
+      arr.push({ lat: b.lat, lng: b.lng, level: b.level || 1 });
+    }
+  });
+  return arr;
+}
+
 // ===== Отрисовка здания =====
 export function renderBuildingDoc(id, data) {
   if (!map) return;
@@ -32,9 +43,9 @@ export function renderBuildingDoc(id, data) {
   marker.bindPopup(makePopupHtml({ id, ...data }));
 
   // Спавн ресурсов только при постройке соответствующего здания
-  if (data.type === 'drovosekdom') spawnTreesBatch(6, data.lat, data.lng);
-  if (data.type === 'minehouse')   spawnRocksBatch(4, data.lat, data.lng);
-  if (data.type === 'fermerdom')   spawnCornBatch(8, data.lat, data.lng);
+  if (data.type === 'drovosekdom') spawnTreesBatch();
+  if (data.type === 'minehouse')   spawnRocksBatch();
+  if (data.type === 'fermerdom')   spawnCornBatch();
 }
 
 // ===== Удаление здания =====

--- a/js/main.js
+++ b/js/main.js
@@ -8,7 +8,7 @@ import { resources, updateResourcePanel, addXP, schedulePlayerSave, setPlayerRef
 import { startWorkersRealtime, hireWoodcutter, hireMiner, hireFermer, moveWorkers } from './worker.js';
 import { showToast, openMarket, closeMarket, openShop, closeShop, editBuilding } from './ui.js';
 import { renderBuildingDoc, unrenderBuildingDoc, upgradeBuilding, deleteBuilding, upgradeBase, cookFood } from './buildings.js';
-import { map, initMap } from './map.js';
+import { map, initMap, spawnTreesBatch, spawnRocksBatch, spawnCornBatch } from './map.js';
 
 // ===== Конфиг Firebase =====
 const firebaseConfig = {
@@ -95,10 +95,15 @@ function startRealtime(){
 }
 
 // ===== Инит игры =====
-initMap();  
-updateResourcePanel(); 
+initMap();
+updateResourcePanel();
 addXP(0);
 requestAnimationFrame(moveWorkers);
+
+// Периодическое пополнение ресурсов
+setInterval(spawnTreesBatch, 30000);
+setInterval(spawnRocksBatch, 30000);
+setInterval(spawnCornBatch, 30000);
 
 // ===== Экспорт глобальных функций =====
 window.hireWoodcutter = hireWoodcutter;


### PR DESCRIPTION
## Summary
- add `getDomAnchors` helper to expose house coordinates
- spawn trees, rocks, and corn near houses up to capacity based on workers and levels
- schedule periodic resource respawn in `main.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6060c2b98833193382831351e7ac0