### PR TITLE
feat: centralize building level configs

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,6 +178,7 @@
 import { initializeApp } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-app.js";
 import { getAuth, GoogleAuthProvider, signInWithPopup, onAuthStateChanged, signOut } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-auth.js";
 import { getFirestore, collection, addDoc, onSnapshot, doc, setDoc, getDoc, updateDoc, deleteDoc, serverTimestamp, getDocs, query, where } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
+import { DROVOSEKDOM_LEVELS, MINEHOUSE_LEVELS, FERMERVOM_LEVELS, HOUSEEAT_LEVELS } from "./js/buildings/config.js";
 
 /* Config */
 const firebaseConfig = {
@@ -301,20 +302,6 @@ const BASE_LEVELS = {
   2: { radius: 220, icon: 148, cost: 200, paint: 64 },
   3: { radius: 300, icon: 176, cost: 500, paint: 128 },
   4: { radius: 380, icon: 208, cost: 1000, paint: 256 },
-};
-const DROVOSEKDOM_LEVELS = {
-  1: { icon: 96, cost: 150, workers: 3, paint: 60 },
-  2: { icon: 112, cost: 350, workers: 5, paint: 72 },
-  3: { icon: 128, cost: 650, workers: 9, paint: 84 },
-  4: { icon: 144, cost: 1050, workers: 15, paint: 96 },
-};
-const MINEHOUSE_LEVELS = JSON.parse(JSON.stringify(DROVOSEKDOM_LEVELS));
-const FERMERVOM_LEVELS = JSON.parse(JSON.stringify(DROVOSEKDOM_LEVELS));
-const HOUSEEAT_LEVELS = {
-  1: { icon: 112, cost: 200, cookMs: 60_000, paint: 72 },
-  2: { icon: 128, cost: 400, cookMs: 45_000, paint: 84 },
-  3: { icon: 144, cost: 700, cookMs: 30_000, paint: 96 },
-  4: { icon: 160, cost: 1100, cookMs: 20_000, paint: 112 }
 };
 
 function randomBrightColor(){ const h = Math.floor(Math.random()*360); return `hsl(${h} 95% 60%)`; }

--- a/js/buildings/config.js
+++ b/js/buildings/config.js
@@ -1,0 +1,34 @@
+export function createLevelConfig(baseWorkers, costs, icons, extras) {
+  const defaultWorkers = [3, 5, 9, 15];
+  const defaultCosts = [150, 350, 650, 1050];
+  const defaultIcons = [96, 112, 128, 144];
+  const defaultExtras = { paint: [60, 72, 84, 96] };
+
+  const workersArr = baseWorkers === undefined ? defaultWorkers : baseWorkers;
+  const costsArr = costs ?? defaultCosts;
+  const iconsArr = icons ?? defaultIcons;
+  const extrasObj = { ...defaultExtras, ...(extras || {}) };
+
+  const levels = {};
+  for (let i = 0; i < costsArr.length; i++) {
+    const level = { icon: iconsArr[i], cost: costsArr[i] };
+    if (workersArr) {
+      level.workers = workersArr[i];
+    }
+    for (const [key, arr] of Object.entries(extrasObj)) {
+      level[key] = arr[i];
+    }
+    levels[i + 1] = level;
+  }
+  return levels;
+}
+
+export const DROVOSEKDOM_LEVELS = createLevelConfig();
+export const MINEHOUSE_LEVELS = createLevelConfig();
+export const FERMERVOM_LEVELS = createLevelConfig();
+export const HOUSEEAT_LEVELS = createLevelConfig(
+  null,
+  [200, 400, 700, 1100],
+  [112, 128, 144, 160],
+  { cookMs: [60_000, 45_000, 30_000, 20_000], paint: [72, 84, 96, 112] }
+);


### PR DESCRIPTION
## Summary
- add factory `createLevelConfig` for building level tables
- use factory to define woodcutter, miner, farmer, and kitchen configs
- import shared configs in main script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a61fdbebe88331bd621d3511a73fe7